### PR TITLE
Add documentation. Tried adding explicit required annotation to the constructor.

### DIFF
--- a/lib/plaid_flutter.dart
+++ b/lib/plaid_flutter.dart
@@ -1,36 +1,42 @@
 import 'dart:async';
 import 'package:flutter/services.dart';
+import 'package:flutter/foundation.dart';
 
-//
-// The available environments to use.
+/// The available environments to use.
 enum EnvOption {
-  //
-  // For testing use,
+  /// For testing use,
+  ///
+  /// A stateful sandbox environment; use test credentials and build out and test your integration
   sandbox,
-  //
-  // For development use
+
+  /// For development use
+  ///
+  /// Test your integration with live credentials; you will need to request access before you can use Plaid's Development environment
   development,
-  //
-  // For production use only
+
+  /// For production use only
+  ///
+  /// Production API environment; all requests are billed
   production
 }
-//
-// Options for specifying the Plaid products to use.
+
+/// Options for specifying the Plaid products to use.
+///
+/// For more information visit the Plaid Products page (https://plaid.com/products/).
 enum ProductOption {
-  //
-  // Verify accounts for payments without micro-deposits.
+  /// Verify accounts for payments without micro-deposits.
   auth,
-  //
-  // Validate income and verify employer info more accurately.
+
+  /// Validate income and verify employer info more accurately.
   income,
-  //
-  // Account and transaction data to better serve users.
+
+  /// Account and transaction data to better serve users.
   transactions,
-  //
-  // Verify user identities with bank account data to reduce fraud.
+
+  /// Verify user identities with bank account data to reduce fraud.
   identity,
-  //
-  // Historical snapshots, real-time summaries, and auditable copies.
+
+  /// Historical snapshots, real-time summaries, and auditable copies.
   assets
 }
 
@@ -44,15 +50,21 @@ typedef void ExitCallback(Map<dynamic, dynamic> metadata);
 
 typedef void EventCallback(String event, Map<dynamic, dynamic> metadata);
 
+/// Provides Plaid Link drop in functionality.
 class PlaidLink {
+  /// Create a Plaid Link.
+  ///
+  /// The [publicKey], [clientName], [env], and [products] arguments are required.
+  ///
+  /// For more information: https://plaid.com/docs/link/ios/
   PlaidLink(
-      {this.publicKey,
-      this.clientName,
-      this.env,
+      {@required this.publicKey,
+      @required this.clientName,
+      @required this.env,
       this.webhook,
       this.oauthRedirectUri,
       this.oauthNonce,
-      this.products,
+      @required this.products,
       this.onAccountLinked,
       this.onAccountLinkError,
       this.onExit,
@@ -60,44 +72,79 @@ class PlaidLink {
       : _channel = MethodChannel('plugins.flutter.io/plaid_flutter') {
     _channel.setMethodCallHandler(_onMethodCall);
   }
-  //
-  // The [MethodChannel] over which this class communicates.
+
+  /// The [MethodChannel] over which this class communicates.
   final MethodChannel _channel;
-  //
-  // Your Plaid public_key available from the Plaid dashboard
+
+  /// Your Plaid public_key available from the Plaid dashboard (https://dashboard.plaid.com/team/keys).
   final String publicKey;
-  //
-  // Displayed to the user once they have successfully linked their account
+
+  /// Displayed to the user once they have successfully linked their account
   final String clientName;
-  //
-  // The API environment selects the Plaid servers with which LinkKit communicates.
+
+  /// The API environment to use. Selects the Plaid servers with which LinkKit communicates.
   final EnvOption env;
-  //
-  // The webhook will receive notifications once a userʼs transactions have been processed and are ready for use.
+
+  /// The webhook will receive notifications once a userʼs transactions have been processed and are ready for use.
   final String webhook;
-  //
-  // An oauthRedirectUri is required to support OAuth authentication
+
+  /// An oauthRedirectUri is required to support OAuth authentication
   final String oauthRedirectUri;
-  //
-  // An oauthNonce is required to support OAuth authentication
+
+  /// An oauthNonce is required to support OAuth authentication
   final String oauthNonce;
-  //
-  // List of Plaid products you would like to use.
+
+  /// The list of Plaid products you would like to use.
   final List<ProductOption> products;
-  //
-  //
+
+  /// Called on a successfull account link.
+  ///
+  /// Two arguments are returned.
+  ///   * [publicToken] The public token for the linked item. It is a string.
+  ///   * [metadata] The additional data related to the link session and account. It is an object.
+  ///
+  /// The [metadata] object provides the following information:
+  ///
+  /// [link_session_id] A unique identifier associated with a user's actions and events through the Link flow. Include this identifier when opening a support ticket for faster turnaround.
+  /// [institution] An object with two properties:
+  ///   * name: The full institution name, such as 'Bank of America'
+  ///   * institution_id: The institution ID, such as ins_100000
+  /// [accounts] A list of objects with the following properties:
+  ///   * id: the id of the selected account
+  ///   * name: the name of the selected account
+  ///   * mask: the last 2-4 alphanumeric characters of an account's official account number. Note that the mask may be non-unique between an Item's accounts, it may also not match the mask that the bank displays to the user. This field is nullable.
+  ///   * type: the account type
+  ///   * subtype: the account subtype
+  ///
+  /// For more information: https://plaid.com/docs/#onsuccess-callback
   final AccountLinkedCallback onAccountLinked;
-  //
-  //
+
+  /// Called on an unrecoverable Plaid Link error.
+  ///
+  /// Two arguments are returned.
+  ///   * [error] The error code.
+  ///   * [metadata] An object containing information about the last error encountered by the user (if any), institution selected by the user, and the most recent API request ID, and the Link session ID.
   final AccountLinkErrorCallback onAccountLinkError;
-  //
-  //
+
+  /// Called when a user exits the Plaid Link flow.
+  ///
+  /// Two arguments are returned.
+  ///   * [error] The error code.
+  ///   * [metadata] An object containing information about the last error encountered by the user (if any), institution selected by the user, and the most recent API request ID, and the Link session ID.
+  ///
+  /// For more information see https://plaid.com/docs/#onexit-callback
   final ExitCallback onExit;
   //
-  //
+  /// Called when a Plaid Link event occurs.
+  ///
+  /// Two arguments are returned.
+  ///   * [eventName] A string representing the event that has just occurred in the Link flow.
+  ///   * [metadata] An object containing information about the event.
+  ///
+  /// For more information see https://plaid.com/docs/#onevent-callback
   final EventCallback onEvent;
-  //
-  //
+
+  /// Handles receiving messages on the [MethodChannel]
   Future<bool> _onMethodCall(MethodCall call) async {
     switch (call.method) {
       case 'onAccountLinked':
@@ -130,8 +177,7 @@ class PlaidLink {
         '${call.method} was invoked but has no handler');
   }
 
-  //
-  //
+  /// Initializes the Plaid Link flow on the device.
   void open() {
     _channel.invokeMethod('open', <String, dynamic>{
       'publicKey': publicKey,


### PR DESCRIPTION
First off, great work! I was looking for something like this. I tried implementing the WebView version using webview_flutter and got an internal error from Plaid's servers. Filed a support ticket but haven't heard back from them yet.

Where my webview implementation failed, your plugin worked. 

I used the Plaid site as a guide and tried to use the dartdoc comment style (///) to give additional context for the API. 

Great work again!