### PR TITLE
Add additional products

### DIFF
--- a/lib/plaid_flutter.dart
+++ b/lib/plaid_flutter.dart
@@ -24,20 +24,29 @@ enum EnvOption {
 ///
 /// For more information visit the Plaid Products page (https://plaid.com/products/).
 enum ProductOption {
+  /// Historical snapshots, real-time summaries, and auditable copies.
+  assets,
+
   /// Verify accounts for payments without micro-deposits.
   auth,
 
-  /// Validate income and verify employer info more accurately.
-  income,
-
-  /// Account and transaction data to better serve users.
-  transactions,
+  /// Verify real-time account balances
+  balance,
 
   /// Verify user identities with bank account data to reduce fraud.
   identity,
 
-  /// Historical snapshots, real-time summaries, and auditable copies.
-  assets
+  /// Validate income and verify employer info more accurately.
+  income,
+
+  /// Build a holistic view of a user’s investments
+  investments,
+
+  /// Access liabilities data for student loans and credit cards
+  liabilities,
+
+  /// Account and transaction data to better serve users.
+  transactions
 }
 
 typedef void AccountLinkedCallback(


### PR DESCRIPTION
As per:
* https://plaid.com/docs/link/ios/#required-items
* https://plaid.com/products/

I tested all of the `product` options at once using the provided example:
```
ProductOption.assets,
ProductOption.auth,
ProductOption.balance,
ProductOption.identity,
ProductOption.income,
ProductOption.investments,
ProductOption.liabilities,
ProductOption.transactions
```

Initially, everything seemed to work fine with all of them, however after selecting a bank and authenticating, I encountered a "No investment accounts" state, which is probably a limitation of Plaid's development mode:
<img width="584" alt="Screen Shot 2020-05-21 at 11 10 38 AM" src="https://user-images.githubusercontent.com/669326/82593584-93a8e180-9b57-11ea-82e7-36da0a8dac5c.png">

I then removed `ProductOption.investments,`, and got a "No liability accounts" state, which again is probably a limitation of Plaid's development mode:
<img width="584" alt="Screen Shot 2020-05-21 at 11 11 09 AM" src="https://user-images.githubusercontent.com/669326/82593598-99062c00-9b57-11ea-9139-b4cacac475e3.png">

After removing both of those options, I verified that the remaining options work at least up the point of receiving a successful `onAccountLinked`  event.
```
ProductOption.assets,
ProductOption.auth,
ProductOption.balance,
ProductOption.identity,
ProductOption.income,
//ProductOption.investments,
//ProductOption.liabilities,
ProductOption.transactions
```