### PR TITLE
Gets correct configuration for Plaid update item mode, when using legacy

### DIFF
--- a/ios/Classes/PlaidFlutterPlugin.m
+++ b/ios/Classes/PlaidFlutterPlugin.m
@@ -79,7 +79,7 @@ static NSString* const kEventKey = @"event";
       
         id<PLKPlaidLinkViewDelegate> linkViewDelegate  = self;
         BOOL usingLinkToken = [linkToken isKindOfClass:[NSString class]];
-        PLKConfiguration* linkConfiguration = usingLinkToken ?
+        PLKConfiguration* linkConfiguration = usingLinkToken && [linkToken hasPrefix:@"link-"] ?
                                             [self getNewLinkConfigurationWithArguments:call.arguments] :
                                             [self getLegacyLinkConfigurationWithArguments:call.arguments];
         


### PR DESCRIPTION
Hi there!

First, thank you for writing such a useful flutter package! 

I have found that when in update mode, with a legacy token (my api backend does not use the new link token), my app crashes on iOS. I'm not sure what the exact cause of the crash is, but it appears that the wrong kind of `PLKConfiguration` is made instantiated, and given to the `PLKPlaidLinkViewController` (again this is _only_ for update mode, which Plaid requires a token for, even for legacy/non-link created items). 

It appears that your iOS package assumes that if _any_ token is provided, it's assumed that it's a link token. However, in the case of updating an item in Plaid (for example, if I change my bank's login credentials), a token is also required. So, when this update token is provided to your iOS code, when deciding which configuration to use, the presence of a token actually results in the wrong type of `PLKPlaidLinkViewController`. 

I found that if I have a legacy token, and go into update mode, that checking the prefix of the token for `link-` fixes the crash for Plaid's update mode. This PR adds an extra `hasPrefix` being equal to `link-` when deciding on what type of configuration to use, making it work in update mode for legacy items. 

I would love to get this merged into your library, or if you'd give any feedback on something my PR could break