### PR TITLE
Add support for payment initiation product type

### DIFF
--- a/lib/src/link_configuration.dart
+++ b/lib/src/link_configuration.dart
@@ -42,7 +42,10 @@ enum LinkProduct {
   liabilities,
 
   /// Account and transaction data to better serve users.
-  transactions
+  transactions,
+
+  /// Gives clients access to details of their users' investment accounts like holdings and buy/sell transactions
+  paymentInitiation,
 }
 
 /// The LinkConfiguration class defines properties to be used by Plaid API.


### PR DESCRIPTION
We are missing the `paymentInitiation` product type:

See iOS product types:
https://github.com/plaid/plaid-link-ios/blob/b4576b6f33b4f9a23e344c98747029d2b6678f13/LinkKit.framework/Headers/PLKConstants.h

https://github.com/plaid/plaid-link-ios/blob/99f98301c7cf335ceaebcc0d7feefcbc04a840f0/LinkDemo-Swift/LinkDemo-Swift/ViewController%2BPaymentInitiation.swift

https://plaid.com/docs/payment-initiation/add-to-app/