### PR TITLE
Remove proguard configuration from Android instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,17 +77,7 @@ Go to the project level `android/app/build.gradle` and make sure you are using a
 
 *NOTE: More info at [https://plaid.com/docs/link/android](https://plaid.com/docs/link/android).*
 
-### 3. Configure to Release
-
-Before creating the release build of your app (which is the default setting when building an APK or App Bundle) you will likely need to add the following line to your ProGuard configuration file as per this [link](https://developer.android.com/studio/build/shrink-code#keep-code) to avoid runtime crashes when the app is built with shrink enabled:
-
-```
--keep class com.google.crypto.tink.proto.** { *; }
-```
-
-*NOTE: The example app is updated with a Proguard rules file(`proguard-rules.pro`)[here](https://github.com/jorgefspereira/plaid_flutter/tree/master/example/android/app/proguard-rules.pro).*
-
 ## TODOs
-- [ ] Web support 
+- [ ] Web support
 - [ ] [Avoid iOS Prepare for distribution configuration](https://plaid.com/docs/link/ios/#prepare-distribution-script)
 - [ ] Implement tests

--- a/example/android/app/proguard-rules.pro
+++ b/example/android/app/proguard-rules.pro
@@ -1,2 +1,1 @@
-## plaid_flutter plugin rules
--keep class com.google.crypto.tink.proto.** { *; }
+## Specific Proguard rules for example go here


### PR DESCRIPTION
Since Plaid link Android SDK 2.2.0 we've stopped relying on `Tink`, so this specific inclusion is no longer required.
(You can check out the `pom.xml` on Maven to verify that: https://bintray.com/plaid/link-android/com.plaid.link/2.2.0#files/com/plaid/link/sdk-core)

Furthermore, we also use `consumer-rules.pro` to package all required exclusion rules directly into our releases so customers don't need to add any Plaid specific Proguard exclusions.