### PR TITLE
Update to latest plaid link

### DIFF
--- a/ios/plaid_flutter.podspec
+++ b/ios/plaid_flutter.podspec
@@ -15,7 +15,7 @@ Enables Plaid in Flutter apps.
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'Plaid', '2.1.0'
+  s.dependency 'Plaid', '2.1.3'
   s.static_framework = true
   s.ios.deployment_target = '11.0'
 end


### PR DESCRIPTION
Updating iOS PlaidLink dependency to 2.1.3 which is the latest as of today, as the current version (2.1.0) breaks the app(iOS14.6 in my case, After successfully adding a bank or whenever we cancel the plaid link popup, the app freezes) after onExit/onSuccess callbacks.

Tested on iOS 14.6 and works fine.