### PR TITLE
Switch from jcenter to mavenCentral.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,7 +4,7 @@ version '1.0-SNAPSHOT'
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -15,7 +15,7 @@ buildscript {
 rootProject.allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -12,7 +12,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 


### PR DESCRIPTION
[Jcenter has been discontinued](https://developer.android.com/studio/build/jcenter-migration), and is currently returning 40X responses.

Applying `jcenter()` in `rootProject.allprojects` is problematic, as its causing other scripts to attempt to access Jcenter (and subsequently fail).

For us, this manifested as the root cause of: https://github.com/RodrigoSMarques/flutter_branch_sdk/issues/186.

Without this change, we are unable to run our Android build! 