### PR TITLE
web jsToMap handles null

### DIFF
--- a/lib/src/platform/plaid_js_map.dart
+++ b/lib/src/platform/plaid_js_map.dart
@@ -42,6 +42,10 @@ class WebConfiguration {
 
 /// A workaround to converting an object from JS to a Dart Map.
 Map jsToMap(jsObject) {
+  if (jsObject == null) {
+    return Map(); 
+  }
+  
   return new Map.fromIterable(
     _getKeysOfObject(jsObject),
     value: (key) => getProperty(jsObject, key),


### PR DESCRIPTION
fixes the following web issue:
```
plaid_js_map.dart:46 Uncaught TypeError: Cannot convert undefined or null to object
    at Function.keys (<anonymous>)
    at Object.jsToMap (plaid_js_map.dart:46:5)
    at plaid_flutter_web.PlaidFlutterPlugin.new.mapFromSuccessMetadata (plaid_flutter_web.dart:141:44)
    at plaid_flutter_web.dart:41:21
    at Object._checkAndCall (operations.dart:367:37)
    at Object.dcall (operations.dart:372:39)
    at Object.ret [as onSuccess] (js_allow_interop_patch.dart:17:11)
    at Object.success (link-initialize.js:1:138485)
    at link-initialize.js:1:100983
```