### PR TITLE
Make package compatible with Gradle 8

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,6 +22,11 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
+    // conditional for compatibility with older gradle versions
+    if (project.android.hasProperty('namespace')) {
+        namespace "com.github.jorgefspereira.plaid_flutter"
+    }
+
     compileSdkVersion 31
 
     defaultConfig {


### PR DESCRIPTION
Solves compatibility error when using the package with Gradle 8.

```
Failed to query the value of property 'buildFlowServiceProperty'.
> Could not isolate value org.jetbrains.kotlin.gradle.plugin.statistics.BuildFlowService$Parameters_Decorated@e3b5897 of type BuildFlowService.Parameters
   > A problem occurred configuring project ':plaid_flutter'.
      > Could not create an instance of type com.android.build.api.variant.impl.LibraryVariantBuilderImpl.
         > Namespace not specified. Specify a namespace in the module's build file. See https://d.android.com/r/tools/upgrade-assistant/set-namespace for information about setting the namespace.

           If you've specified the package attribute in the source AndroidManifest.xml, you can use the AGP Upgrade Assistant to migrate to the namespace value in the build file. Refer to https://d.android.com/r/tools/upgrade-assistant/agp-upgrade-assistant for general information about using the AGP Upgrade Assistant.
```