### PR TITLE
Fix/concorrence issues web

### DIFF
--- a/lib/src/platform/plaid_flutter_web.dart
+++ b/lib/src/platform/plaid_flutter_web.dart
@@ -22,7 +22,7 @@ class PlaidFlutterPlugin extends PlaidPlatformInterface {
   late Stream<LinkObject> _onObjects;
 
   /// Plaid JS object
-  late Plaid _plaid;
+  late Plaid? _plaid;
 
   /// Factory method that initializes the Plaid plugin platform with an instance
   /// of the plugin for the web.
@@ -76,12 +76,13 @@ class PlaidFlutterPlugin extends PlaidPlatformInterface {
 
     _plaid = Plaid.create(options);
     _plaid.open();
+    _plaid?.open();
   }
 
   /// Closes Plaid Link View
   @override
   Future<void> close() async {
-    _plaid.destroy();
+    _plaid?.destroy();
   }
 
   /// Dispose objects

--- a/lib/src/platform/plaid_flutter_web.dart
+++ b/lib/src/platform/plaid_flutter_web.dart
@@ -7,6 +7,7 @@ import 'dart:js';
 // ignore: avoid_web_libraries_in_flutter
 
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
+// import 'package:js/js_util.dart';
 
 import '../core/events.dart';
 import '../core/link_configuration.dart';
@@ -22,7 +23,7 @@ class PlaidFlutterPlugin extends PlaidPlatformInterface {
   late Stream<LinkObject> _onObjects;
 
   /// Plaid JS object
-  late Plaid? _plaid;
+  Plaid? _plaid;
 
   /// Factory method that initializes the Plaid plugin platform with an instance
   /// of the plugin for the web.
@@ -74,8 +75,7 @@ class PlaidFlutterPlugin extends PlaidPlatformInterface {
     options.token = configuration.token;
     options.receivedRedirectUri = configuration.receivedRedirectUri;
 
-    _plaid = Plaid.create(options);
-    _plaid.open();
+    _plaid = await Plaid.create(options);
     _plaid?.open();
   }
 

--- a/lib/src/platform/plaid_js_map.dart
+++ b/lib/src/platform/plaid_js_map.dart
@@ -6,7 +6,7 @@ import 'package:js/js_util.dart';
 
 @JS()
 class Plaid {
-  external static Plaid create(WebConfiguration options);
+  external static Future<Plaid> create(WebConfiguration options);
 
   external void open();
   external void exit();


### PR DESCRIPTION
We are using plaid_flutter in production, and I saw some `LateInitializationError: Field '' has not been initialized.`

![image](https://github.com/jorgefspereira/plaid_flutter/assets/37809501/f5694e86-4a25-4cbd-a187-43b763562969)

![image](https://github.com/jorgefspereira/plaid_flutter/assets/37809501/ecb6eff6-01ee-4ea3-bd0e-1124356dfebd)

`PlaidLink.open() is being called inside initState()`
`PlaidLink.close() is being called on dispose()`

The change above avoid that calling close without calling open throw any exception.
Also there are very few instances where .open() is throwing LateInitializationError what mean that JS part didn't return Plaid instance but it already tried to call open(). Both commits on this PR are to solve each of this issues.