### PR TITLE
test: PlaidLink class

### DIFF
--- a/lib/src/core/link_configuration.dart
+++ b/lib/src/core/link_configuration.dart
@@ -1,8 +1,10 @@
+import 'package:equatable/equatable.dart';
+
 /// The LinkTokenConfiguration only needs a link_token which is created by your app's
 /// server and passed to your app's client to initialize Link. The Link configuration parameters that were
 /// previously set within Link itself are now set via parameters passed to /link/token/create and conveyed
 /// to Link via the link_token.
-class LinkTokenConfiguration {
+class LinkTokenConfiguration extends Equatable {
   /// Specify a link_token to authenticate your app with Link. This is a short lived, one-time use token that should be unique for each Link session
   final String token;
 
@@ -10,9 +12,9 @@ class LinkTokenConfiguration {
   final bool noLoadingState;
 
   /// WEB ONLY: A receivedRedirectUri is required to support OAuth authentication flows when re-launching Link on a mobile device.
-  String? receivedRedirectUri;
+  final String? receivedRedirectUri;
 
-  LinkTokenConfiguration({
+  const LinkTokenConfiguration({
     required this.token,
     this.noLoadingState = false,
     this.receivedRedirectUri,
@@ -26,4 +28,7 @@ class LinkTokenConfiguration {
       'receivedRedirectUri': receivedRedirectUri,
     };
   }
+
+  @override
+  List<Object?> get props => [token, noLoadingState, receivedRedirectUri];
 }

--- a/lib/src/core/link_configuration.dart
+++ b/lib/src/core/link_configuration.dart
@@ -1,10 +1,8 @@
-import 'package:equatable/equatable.dart';
-
 /// The LinkTokenConfiguration only needs a link_token which is created by your app's
 /// server and passed to your app's client to initialize Link. The Link configuration parameters that were
 /// previously set within Link itself are now set via parameters passed to /link/token/create and conveyed
 /// to Link via the link_token.
-class LinkTokenConfiguration extends Equatable {
+class LinkTokenConfiguration {
   /// Specify a link_token to authenticate your app with Link. This is a short lived, one-time use token that should be unique for each Link session
   final String token;
 
@@ -12,9 +10,9 @@ class LinkTokenConfiguration extends Equatable {
   final bool noLoadingState;
 
   /// WEB ONLY: A receivedRedirectUri is required to support OAuth authentication flows when re-launching Link on a mobile device.
-  final String? receivedRedirectUri;
+  String? receivedRedirectUri;
 
-  const LinkTokenConfiguration({
+  LinkTokenConfiguration({
     required this.token,
     this.noLoadingState = false,
     this.receivedRedirectUri,
@@ -28,7 +26,4 @@ class LinkTokenConfiguration extends Equatable {
       'receivedRedirectUri': receivedRedirectUri,
     };
   }
-
-  @override
-  List<Object?> get props => [token, noLoadingState, receivedRedirectUri];
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,6 @@ dependencies:
     sdk: flutter
   plugin_platform_interface: ^2.1.2
   js: ^0.6.3
-  equatable: ^2.0.5
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ screenshots:
 environment:
   sdk: ">=3.0.0 <4.0.0"
   flutter: ">=3.10.0"
-  
+
 dependencies:
   flutter:
     sdk: flutter
@@ -24,6 +24,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^3.0.0
+  mocktail: ^1.0.0
 
 flutter:
   plugin:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,6 +19,7 @@ dependencies:
     sdk: flutter
   plugin_platform_interface: ^2.1.2
   js: ^0.6.3
+  equatable: ^2.0.5
 
 dev_dependencies:
   flutter_test:

--- a/test/core/plaid_link_test.dart
+++ b/test/core/plaid_link_test.dart
@@ -1,0 +1,149 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:plaid_flutter/plaid_flutter.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+
+class _MockPlaidPlatformInterface extends Mock
+    with MockPlatformInterfaceMixin
+    implements PlaidPlatformInterface {}
+
+class _MockLinkEvent extends Mock implements LinkEvent {}
+
+class _MockLinkExit extends Mock implements LinkExit {}
+
+class _MockLinkSuccess extends Mock implements LinkSuccess {}
+
+main() {
+  group('PlaidLink', () {
+    late PlaidPlatformInterface plaidPlatformInterface;
+
+    setUp(() {
+      plaidPlatformInterface = _MockPlaidPlatformInterface();
+      PlaidPlatformInterface.instance = plaidPlatformInterface;
+    });
+
+    test('can be instantiated', () {
+      var plaidLink = PlaidLink();
+      expect(plaidLink, isNotNull);
+    });
+
+    group('onEvent', () {
+      late LinkEvent linkEvent;
+
+      setUp(() {
+        linkEvent = _MockLinkEvent();
+        when(
+          () => plaidPlatformInterface.onObject,
+        ).thenAnswer((_) => Stream.fromIterable([linkEvent]));
+      });
+
+      test('emits a LinkEvent', () async {
+        await expectLater(PlaidLink.onEvent, emits(linkEvent));
+      });
+
+      test('calls platform.onObject', () {
+        PlaidLink.onEvent;
+
+        verify(
+          () => plaidPlatformInterface.onObject,
+        ).called(1);
+      });
+    });
+
+    group('onExit', () {
+      late LinkExit linkExitEvent;
+
+      setUp(() {
+        linkExitEvent = _MockLinkExit();
+        when(
+          () => plaidPlatformInterface.onObject,
+        ).thenAnswer((_) => Stream.fromIterable([linkExitEvent]));
+      });
+
+      test('emits a LinkExit', () async {
+        await expectLater(PlaidLink.onExit, emits(linkExitEvent));
+      });
+
+      test('calls platform.onObject', () {
+        PlaidLink.onExit;
+
+        verify(
+          () => plaidPlatformInterface.onObject,
+        ).called(1);
+      });
+    });
+
+    group('onSuccess', () {
+      late LinkSuccess linkSuccess;
+
+      setUp(() {
+        linkSuccess = _MockLinkSuccess();
+        when(
+          () => plaidPlatformInterface.onObject,
+        ).thenAnswer((_) => Stream.fromIterable([linkSuccess]));
+      });
+
+      test('emits a LinkSuccess', () async {
+        await expectLater(PlaidLink.onSuccess, emits(linkSuccess));
+      });
+
+      test('calls platform.onObject', () {
+        PlaidLink.onSuccess;
+
+        verify(
+          () => plaidPlatformInterface.onObject,
+        ).called(1);
+      });
+    });
+
+    group('open', () {
+      test('calls platform.open', () async {
+        const token = 'token';
+
+        final linkTokenConfiguration = LinkTokenConfiguration(token: token);
+
+        when(
+          () => plaidPlatformInterface.open(
+              configuration: linkTokenConfiguration),
+        ).thenAnswer(Future.value);
+
+        await PlaidLink.open(configuration: linkTokenConfiguration);
+
+        verify(
+          () => plaidPlatformInterface.open(
+              configuration: linkTokenConfiguration),
+        ).called(1);
+      });
+    });
+
+    group('close', () {
+      test('calls platform.close', () async {
+        when(
+          () => plaidPlatformInterface.close(),
+        ).thenAnswer(Future.value);
+
+        await PlaidLink.close();
+
+        verify(
+          () => plaidPlatformInterface.close(),
+        ).called(1);
+      });
+    });
+
+    group('resumeAfterTermination', () {
+      test('calls platform.resumeAfterTermination', () async {
+        const redirectUri = 'redirectUri';
+
+        when(
+          () => plaidPlatformInterface.resumeAfterTermination(redirectUri),
+        ).thenAnswer(Future.value);
+
+        await PlaidLink.resumeAfterTermination(redirectUri);
+
+        verify(
+          () => plaidPlatformInterface.resumeAfterTermination(redirectUri),
+        ).called(1);
+      });
+    });
+  });
+}

--- a/test/core/plaid_link_test.dart
+++ b/test/core/plaid_link_test.dart
@@ -100,7 +100,7 @@ main() {
       test('calls platform.open', () async {
         const token = 'token';
 
-        final linkTokenConfiguration = LinkTokenConfiguration(token: token);
+        const linkTokenConfiguration = LinkTokenConfiguration(token: token);
 
         when(
           () => plaidPlatformInterface.open(


### PR DESCRIPTION
Hello @jorgefspereira !

First of all thanks for continue giving support to this flutter package!

Also thanks for solving my recently created an issue https://github.com/jorgefspereira/plaid_flutter/issues/114, this allowed me to create unit tests in my own code base. 

As suggested, I decided to start doing some unit tests on this integration plugin.

This PR includes unit tests for the the PlaidLink class. Test for the onEvent, onExit, onSuccess, open, close and resumeAfterTermination methods. To achieve this I've also added a dependency to the [mocktail](https://pub.dev/packages/mocktail) package.

Let me know what you think.

Note: I'll probably continue doing some unit tests if you'd like of course.