### PR TITLE
[Fix] Issue 125

### DIFF
--- a/ios/Classes/PlaidFlutterPlugin.m
+++ b/ios/Classes/PlaidFlutterPlugin.m
@@ -107,7 +107,6 @@ static NSString* const kTypeKey = @"type";
         [strongSelf sendEventWithArguments:@{kTypeKey: kOnEventType,
                                              kNameKey: [PlaidFlutterPlugin stringForEventName: event.eventName] ?: @"",
                                              kMetadataKey: [PlaidFlutterPlugin dictionaryFromEventMetadata: event.eventMetadata]}];
-
         if ([eventName isEqualToString:@"HANDOFF"]) {
             // This event is only received after onSuccess. So it's safe to deallocate the handler now.
             _linkHandler = nil;


### PR DESCRIPTION
This PR resolves [issue 125](https://github.com/jorgefspereira/plaid_flutter/issues/125). It's similar to the [latest changes ](https://github.com/plaid/react-native-plaid-link-sdk/pull/654 )made to the React Native SDK. 

The root cause of this issue is that `HANDOFF` isn't sent until after `onSuccess` since the hander is being deallocated in the successHandler the eventHander never receives the final `HANDOFF` event. 

This PR: 
1. Deallocates the hander for OnExit because there won't be a `HANDOFF` event.
2. Stop deallocating the hander for onSuccess.
3. Deallocates the handler once the `HANDOFF` event is received.

