### PR TITLE
[FIX] Issue 103

### DIFF
--- a/ios/Classes/PlaidFlutterPlugin.m
+++ b/ios/Classes/PlaidFlutterPlugin.m
@@ -1,3 +1,4 @@
+#import "TopViewControllerHelper.h"
 #import "PlaidFlutterPlugin.h"
 #import <LinkKit/LinkKit.h>
 
@@ -138,8 +139,8 @@ static NSString* const kTypeKey = @"type";
         __weak typeof(self) weakSelf = self;
         ///
         void(^presentationHandler)(UIViewController *) = ^(UIViewController *linkViewController) {
-            UIViewController* rootViewController = [UIApplication sharedApplication].delegate.window.rootViewController;
-            [rootViewController presentViewController:linkViewController animated:YES completion:nil];
+            UIViewController *topViewController = [[UIApplication sharedApplication] topViewController];
+            [topViewController presentViewController:linkViewController animated:YES completion:nil];
             didPresent = YES;
         };
 

--- a/ios/Classes/PlaidFlutterPlugin.m
+++ b/ios/Classes/PlaidFlutterPlugin.m
@@ -140,14 +140,18 @@ static NSString* const kTypeKey = @"type";
         __weak typeof(self) weakSelf = self;
         ///
         void(^presentationHandler)(UIViewController *) = ^(UIViewController *linkViewController) {
-            UIViewController *topViewController = [[UIApplication sharedApplication] topViewController];
-            [topViewController presentViewController:linkViewController animated:YES completion:nil];
-            weakSelf->_presentedViewController = linkViewController;
-            didPresent = YES;
+            __strong typeof(self) strongSelf = weakSelf;
+            if (strongSelf) {
+                UIViewController *topViewController = [[UIApplication sharedApplication] topViewController];
+                [topViewController presentViewController:linkViewController animated:YES completion:nil];
+                strongSelf->_presentedViewController = linkViewController;
+                didPresent = YES;
+            }
         };
 
         void(^dismissalHandler)(UIViewController *) = ^(UIViewController *linkViewController) {
-            if (didPresent) {
+            __strong typeof(self) strongSelf = weakSelf;
+            if (strongSelf && didPresent) {
                 [weakSelf close];
                 didPresent = NO;
             }

--- a/ios/Classes/PlaidFlutterPlugin.m
+++ b/ios/Classes/PlaidFlutterPlugin.m
@@ -22,6 +22,7 @@ static NSString* const kTypeKey = @"type";
     FlutterEventSink _eventSink;
     id<PLKHandler> _linkHandler;
     NSError *creationError;
+    UIViewController *_presentedViewController;
 }
 
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar> *)registrar {
@@ -141,6 +142,7 @@ static NSString* const kTypeKey = @"type";
         void(^presentationHandler)(UIViewController *) = ^(UIViewController *linkViewController) {
             UIViewController *topViewController = [[UIApplication sharedApplication] topViewController];
             [topViewController presentViewController:linkViewController animated:YES completion:nil];
+            weakSelf->_presentedViewController = linkViewController;
             didPresent = YES;
         };
 
@@ -187,8 +189,10 @@ static NSString* const kTypeKey = @"type";
 }
 
 - (void) close {
-    UIViewController* rootViewController = [UIApplication sharedApplication].delegate.window.rootViewController;
-    [rootViewController dismissViewControllerAnimated:YES completion:nil];
+    if (_presentedViewController) {
+        [_presentedViewController dismissViewControllerAnimated:YES completion:nil];
+        _presentedViewController = nil; // Reset after dismissal
+    }
 }
 
 - (void) closeWithResult:(FlutterResult)result {

--- a/ios/Classes/TopViewControllerHelper.h
+++ b/ios/Classes/TopViewControllerHelper.h
@@ -1,0 +1,8 @@
+#import <UIKit/UIKit.h>
+
+@interface UIApplication (TopViewController)
+
+- (UIViewController *)topViewController;
+- (UIViewController *)topViewControllerForWindow:(UIWindow *)window;
+
+@end

--- a/ios/Classes/TopViewControllerHelper.m
+++ b/ios/Classes/TopViewControllerHelper.m
@@ -1,0 +1,34 @@
+#import "TopViewControllerHelper.h"
+
+@implementation UIApplication (TopViewController)
+
+- (UIViewController *)topViewControllerForWindow:(UIWindow *)window {
+    UIViewController *topViewController = window.rootViewController;
+    while (topViewController.presentedViewController) {
+        topViewController = topViewController.presentedViewController;
+    }
+    
+    if ([topViewController isKindOfClass:[UINavigationController class]]) {
+        topViewController = [(UINavigationController *)topViewController topViewController];
+    } else if ([topViewController isKindOfClass:[UITabBarController class]]) {
+        topViewController = [(UITabBarController *)topViewController selectedViewController];
+    }
+    
+    return topViewController;
+}
+
+- (UIViewController *)topViewController {
+    // Handle multi-window/scene
+    UIScene *scene = [UIApplication sharedApplication].connectedScenes.anyObject;
+    if ([scene isKindOfClass:[UIWindowScene class]]) {
+        UIWindowScene *windowScene = (UIWindowScene *)scene;
+        for (UIWindow *window in windowScene.windows) {
+            if (window.isKeyWindow) {
+                return [self topViewControllerForWindow:window];
+            }
+        }
+    }
+    return nil;
+}
+
+@end


### PR DESCRIPTION
While integrating the plaid_flutter plugin into a native app, an issue was encountered where the presented view controller was not correctly managed in scenarios involving multiple scenes or when presenting modals on top of other presented modals. This issue was reported in the GitHub repository [here](https://github.com/jorgefspereira/plaid_flutter/issues/103).

## This PR addresses the issue by implementing the following changes:

- Support for Multiple Scenes: The logic has been updated to correctly handle multiple scenes, ensuring that the view controller is presented in the appropriate context.
- Top View Controller Presentation: The code now correctly presents the link modal on top of any existing presented modals, preventing UI disruptions.
- Correct Dismissal Handling: The close method has been modified to dismiss only the view controller that was presented by the plugin, avoiding unintended dismissals of other modals or root view controllers.

Testing
- Verified that the view controller is presented on top of the current top view controller across multiple scenes.
- Confirmed that only the view controller managed by the plugin is dismissed when the close method is called.

This fix should resolve the reported issue and improve the stability and usability of the plugin in native apps while maintaining the current functionality on Flutter ones.