### PR TITLE
Fix: Prevent handler deallocation on multi-item Link handoff

### DIFF
--- a/ios/Classes/PlaidFlutterPlugin.m
+++ b/ios/Classes/PlaidFlutterPlugin.m
@@ -116,9 +116,13 @@ static NSString* const kTypeKey = @"type";
         [strongSelf sendEventWithArguments:@{kTypeKey: kOnEventType,
                                              kNameKey: [PlaidFlutterPlugin stringForEventName: event.eventName] ?: @"",
                                              kMetadataKey: [PlaidFlutterPlugin dictionaryFromEventMetadata: event.eventMetadata]}];
+
+        // If the HANDOFF event is received.                                             
         if (event.eventName.value == PLKEventNameValueHandoff) {
-            // This event is only received after onSuccess. So it's safe to deallocate the handler now.
-            strongSelf->_linkHandler = nil;
+            // Only deallocate the handler if the view controller is no longer presented.
+            if (strongSelf->_presentedViewController == nil) {
+                strongSelf->_linkHandler = nil;
+            }
         }
     };
 


### PR DESCRIPTION
Resolves Issue #141 

Note: This fix only related to [multi-item Link](https://plaid.com/docs/link/multi-item-link/).

The root cause is in [this code](https://github.com/jorgefspereira/plaid_flutter/blob/master/ios/Classes/PlaidFlutterPlugin.m#L121):

```objective-c
if (event.eventName.value == PLKEventNameValueHandoff) {
    // This event is only received after onSuccess. So it's safe to deallocate the handler now.
    strongSelf->_linkHandler = nil;
}
```

When the `HANDOFF` event is triggered after linking the first item, the handler is deallocated on iOS, which prevents onSuccess from being called for subsequent items.

In our React Native integration, we avoid this by [checking if Link is still presenting](https://github.com/plaid/react-native-plaid-link-sdk/blob/master/ios/RNLinksdk.mm#L108). Applying a similar approach should resolve the issue here as well.