### PR TITLE
Bugfix: Rename mismatched variable _configuration in code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ In order to initialize Plaid Link, you will need to create a link_token at [/lin
 ``` dart
 ...
 
-LinkTokenConfiguration configuration = LinkTokenConfiguration(
+LinkTokenConfiguration _configuration = LinkTokenConfiguration(
     token: "<GENERATED_LINK_TOKEN>",
 );
 


### PR DESCRIPTION
Hi [Jorge](https://github.com/jorgefspereira),

I noticed a small bug in the documentation code sample where the variable is declared as '**configuration**', but later referred to as **_configuration**. Since _configuration is never declared, this results in a runtime error.

To resolve this, I updated the code to consistently use _configuration as the variable name. I believe this change improves clarity and prevents confusion or errors for developers referencing the example.

Please feel free to review and merge this change if it aligns with your standards. I’m always open to suggestions or improvements, so don’t hesitate to reach out.