### PR TITLE
upgrade native sdk versions

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -43,6 +43,6 @@ android {
     }
 
     dependencies {
-        implementation 'com.plaid.link:sdk-core:5.1.1'
+        implementation 'com.plaid.link:sdk-core:5.3.1'
     }
 }

--- a/ios/plaid_flutter.podspec
+++ b/ios/plaid_flutter.podspec
@@ -15,7 +15,7 @@ Enables Plaid in Flutter apps.
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'Plaid', '6.2.1'
+  s.dependency 'Plaid', '6.4.0'
   s.static_framework = true
   s.ios.deployment_target = '14.0'
 end


### PR DESCRIPTION
Upgrades the Android SDK to [5.3.1](https://github.com/plaid/plaid-link-android/releases/tag/v5.3.1) and the iOS SDK to [6.4.0](https://github.com/plaid/plaid-link-ios/releases/tag/6.4.0). This includes a fix for this bug: https://github.com/plaid/plaid-link-android/issues/316, which is fix that was request by a flutter user.


@jorgefspereira, it would be very much appreciated if we could upgrade the SDK versions. Please let me know if I can help with the process! Thank you!