### PR TITLE
Bump Plaid Android SDK to 5.5.2 and iOS SDK to 6.4.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 5.1.1
 
 * Fix web/wasm JS interop type conversion for callbacks
+* Updated iOS SDK to 6.4.7
+* Updated Android SDK to 5.5.2
 
 ## 5.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Fix web/wasm JS interop type conversion for callbacks
 * Updated iOS SDK to 6.4.7
 * Updated Android SDK to 5.5.2
+* Added optional params support for submit on iOS and Android
 
 ## 5.1.0
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -44,6 +44,6 @@ android {
     }
 
     dependencies {
-        implementation 'com.plaid.link:sdk-core:5.5.0'
+        implementation 'com.plaid.link:sdk-core:5.5.2'
     }
 }

--- a/android/src/main/java/com/github/jorgefspereira/plaid_flutter/PlaidFlutterPlugin.java
+++ b/android/src/main/java/com/github/jorgefspereira/plaid_flutter/PlaidFlutterPlugin.java
@@ -7,6 +7,7 @@ import android.content.Intent;
 
 import androidx.annotation.NonNull;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.HashMap;
 import java.util.ArrayList;
@@ -256,7 +257,7 @@ public class PlaidFlutterPlugin implements FlutterPlugin, MethodCallHandler, Eve
     String dateOfBirth = dobObj instanceof String ? (String) dobObj : null;
 
     if (plaidHandler != null) {
-      SubmissionData submissionData = new SubmissionData(phoneNumber, dateOfBirth);
+      SubmissionData submissionData = new SubmissionData(phoneNumber, dateOfBirth, Collections.emptyMap());
       plaidHandler.submit(submissionData);
     }
 
@@ -373,4 +374,3 @@ public class PlaidFlutterPlugin implements FlutterPlugin, MethodCallHandler, Eve
   }
 
 }
-

--- a/android/src/main/java/com/github/jorgefspereira/plaid_flutter/PlaidFlutterPlugin.java
+++ b/android/src/main/java/com/github/jorgefspereira/plaid_flutter/PlaidFlutterPlugin.java
@@ -50,6 +50,7 @@ public class PlaidFlutterPlugin implements FlutterPlugin, MethodCallHandler, Eve
   /// SubmissionData
   private static final String PHONE_NUMBER = "phoneNumber";
   private static final String DATE_OF_BIRTH = "dateOfBirth";
+  private static final String PARAMS = "params";
 
   /// LinkResultHandler
   private static final String EVENT_ON_SUCCESS = "success";
@@ -256,12 +257,34 @@ public class PlaidFlutterPlugin implements FlutterPlugin, MethodCallHandler, Eve
     Object dobObj = arguments.get(DATE_OF_BIRTH);
     String dateOfBirth = dobObj instanceof String ? (String) dobObj : null;
 
+    Map<String, String> params = getStringMap(arguments.get(PARAMS));
+
     if (plaidHandler != null) {
-      SubmissionData submissionData = new SubmissionData(phoneNumber, dateOfBirth, Collections.emptyMap());
+      SubmissionData submissionData = new SubmissionData(phoneNumber, dateOfBirth, params);
       plaidHandler.submit(submissionData);
     }
 
     reply.success(null);
+  }
+
+  private Map<String, String> getStringMap(Object object) {
+    if (!(object instanceof Map)) {
+      return Collections.emptyMap();
+    }
+
+    Map<?, ?> rawMap = (Map<?, ?>) object;
+    Map<String, String> result = new HashMap<>();
+
+    for (Map.Entry<?, ?> entry : rawMap.entrySet()) {
+      Object key = entry.getKey();
+      Object value = entry.getValue();
+
+      if (key instanceof String && value instanceof String) {
+        result.put((String) key, (String) value);
+      }
+    }
+
+    return result;
   }
 
   /// Configuration Parsing

--- a/example/README.md
+++ b/example/README.md
@@ -101,6 +101,7 @@ class _MyAppState extends State<MyApp> {
                         PlaidLink.submit(
                           SubmissionData(
                             phoneNumber: "14155550015",
+                            params: {"client_user_id": "optional-user-id"},
                           ),
                         );
                       }

--- a/example/lib/example_link_token.dart
+++ b/example/lib/example_link_token.dart
@@ -125,6 +125,7 @@ class _ExampleLinkTokenState extends State<ExampleLinkToken> {
                       SubmissionData(
                         phoneNumber: "14155550015",
                         dateOfBirth: "1975-01-18",
+                        params: {"client_user_id": "optional-user-id"},
                       ),
                     );
                   }

--- a/ios/Classes/PlaidFlutterPlugin.m
+++ b/ios/Classes/PlaidFlutterPlugin.m
@@ -6,6 +6,7 @@
 static NSString* const kTokenKey = @"token";
 static NSString* const kPhoneNumberKey = @"phoneNumber";
 static NSString* const kDateOfBirthKey = @"dateOfBirth";
+static NSString* const kParamsKey = @"params";
 static NSString* const kContinueRedirectUriKey = @"redirectUri";
 static NSString* const kNoLoadingStateKey = @"noLoadingState";
 static NSString* const kOnSuccessType = @"success";
@@ -252,6 +253,7 @@ static NSString* const kSimulatedBehavior = @"simulatedBehavior";
 - (void) submit: (id _Nullable)arguments withResult:(FlutterResult)result{
     NSString* phoneNumber = arguments[kPhoneNumberKey];
     NSString* dateOfBirth = arguments[kDateOfBirthKey];
+    id paramsObject = arguments[kParamsKey];
     
     if (_linkHandler) {
         PLKSubmissionData *data = [[PLKSubmissionData alloc] init];
@@ -262,6 +264,16 @@ static NSString* const kSimulatedBehavior = @"simulatedBehavior";
         
         if (dateOfBirth && ![dateOfBirth isKindOfClass:[NSNull class]]) {
             data.dateOfBirth = dateOfBirth;
+        }
+
+        if (paramsObject && [paramsObject isKindOfClass:[NSDictionary class]]) {
+            NSMutableDictionary<NSString *, NSString *> *params = [NSMutableDictionary dictionary];
+            [(NSDictionary *)paramsObject enumerateKeysAndObjectsUsingBlock:^(id key, id value, BOOL *stop) {
+                if ([key isKindOfClass:[NSString class]] && [value isKindOfClass:[NSString class]]) {
+                    params[key] = value;
+                }
+            }];
+            data.params = params;
         }
         
         [_linkHandler submit: data];

--- a/ios/plaid_flutter.podspec
+++ b/ios/plaid_flutter.podspec
@@ -15,8 +15,7 @@ Enables Plaid in Flutter apps.
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'Plaid', '6.4.3'
+  s.dependency 'Plaid', '6.4.7'
   s.static_framework = true
   s.ios.deployment_target = '14.0'
 end
-

--- a/lib/src/core/link_configuration.dart
+++ b/lib/src/core/link_configuration.dart
@@ -52,15 +52,20 @@ class SubmissionData {
   /// The end user's date of birth. To be provided in the format "yyyy-mm-dd".
   String? dateOfBirth;
 
+  /// Additional optional values to submit during a Link session.
+  Map<String, String>? params;
+
   SubmissionData({
     this.phoneNumber,
     this.dateOfBirth,
+    this.params,
   });
 
   Map<String, dynamic> toJson() {
     return <String, dynamic>{
       'phoneNumber': phoneNumber,
       'dateOfBirth': dateOfBirth,
+      'params': params,
     };
   }
 }

--- a/test/core/plaid_link_test.dart
+++ b/test/core/plaid_link_test.dart
@@ -91,22 +91,11 @@ main() {
 
     group('open', () {
       test('calls platform.open', () async {
-        const token = 'token';
-        const linkTokenConfiguration = LinkTokenConfiguration(token: token);
-
-        when(
-          () => plaidPlatformInterface.create(
-            configuration: linkTokenConfiguration,
-          ),
-        ).thenAnswer(Future.value);
+        when(() => plaidPlatformInterface.open()).thenAnswer(Future.value);
 
         await PlaidLink.open();
 
-        verify(
-          () => plaidPlatformInterface.create(
-            configuration: linkTokenConfiguration,
-          ),
-        ).called(1);
+        verify(() => plaidPlatformInterface.open()).called(1);
       });
     });
 
@@ -136,6 +125,70 @@ main() {
 
         verify(
           () => plaidPlatformInterface.resumeAfterTermination(redirectUri),
+        ).called(1);
+      });
+    });
+
+    group('submit', () {
+      test('SubmissionData does not require params', () {
+        final submissionData = SubmissionData();
+
+        expect(
+          submissionData.toJson(),
+          {
+            'phoneNumber': null,
+            'dateOfBirth': null,
+            'params': null,
+          },
+        );
+      });
+
+      test('SubmissionData supports existing phone and date of birth usage',
+          () {
+        final submissionData = SubmissionData(
+          phoneNumber: '14155550015',
+          dateOfBirth: '1975-01-18',
+        );
+
+        expect(
+          submissionData.toJson(),
+          {
+            'phoneNumber': '14155550015',
+            'dateOfBirth': '1975-01-18',
+            'params': null,
+          },
+        );
+      });
+
+      test('SubmissionData serializes optional params', () {
+        final submissionData = SubmissionData(
+          params: {'client_user_id': 'optional-user-id'},
+        );
+
+        expect(
+          submissionData.toJson(),
+          {
+            'phoneNumber': null,
+            'dateOfBirth': null,
+            'params': {'client_user_id': 'optional-user-id'},
+          },
+        );
+      });
+
+      test('calls platform.submit without requiring params', () async {
+        final submissionData = SubmissionData(
+          phoneNumber: '14155550015',
+          dateOfBirth: '1975-01-18',
+        );
+
+        when(
+          () => plaidPlatformInterface.submit(submissionData),
+        ).thenAnswer(Future.value);
+
+        await PlaidLink.submit(submissionData);
+
+        verify(
+          () => plaidPlatformInterface.submit(submissionData),
         ).called(1);
       });
     });


### PR DESCRIPTION
## Summary
- Bumps Android Plaid Link SDK from 5.5.0 to 5.5.2.
- Bumps iOS Plaid SDK from 6.4.3 to 6.4.7.
- Adds optional SubmissionData.params support for submit on iOS and Android, matching the React Native data shape.
- Keeps params fully optional: existing phone/date-only integrations continue to compile and submit without sending params.
- Does not change Android tooling, iOS deployment target, Flutter package version, or missing-handler/no-op behavior.

## Validation
- PASS: flutter pub get
- PASS: flutter test
- PASS: cd example && flutter build apk --debug
- PASS: cd example/ios && pod install
- PASS: cd example && flutter build ios --simulator
- Existing lint infos: flutter analyze reports 5 pre-existing info-level issues in example imports, example widget const usage, and enum naming.